### PR TITLE
Pin go-cfclient

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,6 +36,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/cloudfoundry-community/go-cfclient"
+  revision = "5f2155bebf6f16875beeb57976328f352d99f312"
 
 [[constraint]]
   name = "github.com/jinzhu/gorm"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Pin go-cfclient to a version before the incident with the cloudfoundry-community org

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Pinning this package to a commit before there was an incident with the cloudfoundry-community org gives us more confidence in the integrity of the code
