### PR TITLE
using <=

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/cloudfoundry-community/go-cfclient"
-  version = "v3.0.0-alpha.6"
+  version = "<=v3.0.0-alpha.6"
 
 [[constraint]]
   name = "github.com/jinzhu/gorm"


### PR DESCRIPTION
## Changes proposed in this pull request:

- Allows version to be less than or equal to the set version

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None