### PR TITLE
update certificate delete logic 

### DIFF
--- a/utils/iam_test.go
+++ b/utils/iam_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
-
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
@@ -17,14 +16,14 @@ type mockIAM struct {
 	deleteCertificateCalled bool
 }
 
-func (m mockIAM) GetServerCertificate(*iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error) {
+func (m *mockIAM) GetServerCertificate(*iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error) {
 	if m.getCertificateError != nil {
 		return nil, m.getCertificateError
 	}
 	return nil, nil
 }
 
-func (m mockIAM) DeleteServerCertificate(*iam.DeleteServerCertificateInput) (*iam.DeleteServerCertificateOutput, error) {
+func (m *mockIAM) DeleteServerCertificate(*iam.DeleteServerCertificateInput) (*iam.DeleteServerCertificateOutput, error) {
 	m.deleteCertificateCalled = true
 	if m.deleteCertificateErr != nil {
 		return nil, m.deleteCertificateErr
@@ -46,6 +45,7 @@ func TestDeleteCertificate(t *testing.T) {
 			iamUtils: &IamUtils{
 				Service: &mockIAM{},
 			},
+			expectDeleteCertificateCalled: true,
 		},
 		"unexpected get error should not be returned": {
 			iamUtils: &IamUtils{
@@ -53,6 +53,7 @@ func TestDeleteCertificate(t *testing.T) {
 					getCertificateError: getCertificateErr,
 				},
 			},
+			expectDeleteCertificateCalled: true,
 		},
 		"NoSuchEntity get error should not be returned": {
 			iamUtils: &IamUtils{


### PR DESCRIPTION
## Changes proposed in this pull request:

Right delete service requests for instances where the certificate was somehow already deleted are failing with `AccessDenied` errors. According to AWS support, the only way to make a DeleteServerCertificate operation return `NoSuchEntity` error instead of `AccessDenied` is to give `iam:DeleteServerCertificate` on all certificates (`*`), rather than certificates under the path managed by this broker. However, these permissions would allow this domain broker to delete certificates managed by other brokers, so we do not want to do that.

Instead, we have updated the delete certificate code to check if the certificate exists before attempting the deletion. If the certificate no longer exists, then we do not attempt the deletion. 

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Should be no security impact. Just allowing deletion to succeed for edge case of inconsistent state where certificate was somehow already deleted from AWS.
