### PR TITLE
Delete route operations

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -44,6 +44,16 @@ const (
 	Deprovisioned       = "deprovisioned"
 )
 
+type OperationStatus int
+
+const (
+	InProgress OperationStatus = iota + 1 // EnumIndex = 1
+)
+
+func (o OperationStatus) String() string {
+	return [...]string{"in progress"}[o-1]
+}
+
 var (
 	helperLogger = lager.NewLogger("helper-logger")
 )
@@ -666,7 +676,29 @@ func (m *RouteManager) updateProvisioning(r *Route) error {
 }
 
 func (m *RouteManager) deleteAssociatedOperationsForRoute(route_guid string) error {
-	return m.db.Raw(`DELETE FROM operations WHERE route_guid = $1`, route_guid).Error
+	return m.db.Exec(`DELETE FROM operations WHERE route_guid = $1`, route_guid).Error
+}
+
+func (m *RouteManager) hasActiveOperations(route_guid string) (bool, error) {
+	inProgressState := InProgress
+
+	rows, err := m.db.Raw(
+		`SELECT id FROM operations WHERE route_guid = $1 AND state = $2`,
+		route_guid,
+		inProgressState.String(),
+	).Rows()
+
+	if err != nil {
+		return false, err
+	}
+
+	defer rows.Close()
+	var rowCount int
+	for rows.Next() {
+		rowCount += 1
+	}
+
+	return rowCount > 0, err
 }
 
 func (m *RouteManager) Destroy(guid string) error {
@@ -693,8 +725,16 @@ func (m *RouteManager) Destroy(guid string) error {
 	// Attempting to delete a route record without deleting the associated operations first
 	// will cause a foreign-key constraint error, so we are manually deleting any associated
 	// operation records before attempting the route deletion.
-	if err := m.deleteAssociatedOperationsForRoute(guid); err != nil {
+	hasActiveOperationsPending, err := m.hasActiveOperations(guid)
+	if err != nil {
 		return err
+	}
+	if !hasActiveOperationsPending {
+		if err := m.deleteAssociatedOperationsForRoute(guid); err != nil {
+			return err
+		}
+	} else {
+		return errors.New("cannot delete route: there are active operations at this time. Please try again later")
 	}
 	return m.db.Delete(route).Error
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Currently, delete attempts for this broker are failing with:

```
 pq: update or delete on table "routes" violates foreign key constraint "fk_operations_route_guid_routes" on table "operations"
```

Manual querying of the associated database confirms that there is indeed an `operations` table, even though there is no associated `gorm.Model` that seems to manage this table. At this time, the provenance of this table cannot be explained.

Regardless, it is clear that there is no logic in the code to delete operations associated to a route via the `route_guid` foreign key, so the foreign key constraint violation on deletion makes sense.

In order to allow route deletion to succeed where there are associated operations, this PR adds the logic to delete those associated operations before attempting the route deletion, thus avoiding the foreign-key constraint error.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Should be no security impact, just addressing a bug in the service broker logic
