### PR TITLE
Switch to capi v3

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -114,8 +114,8 @@ dns_regex="name: (.*), value: (.*), ttl: (.*)"
 
 elapsed=300
 until [ "${elapsed}" -le 0 ]; do
-  status=$(cf curl "/v2/service_instances/${service_guid}")
-  description=$(echo "${status}" | jq -r '.entity.last_operation.description')
+  status=$(cf curl "/v3/service_instances/${service_guid}")
+  description=$(echo "${status}" | jq -r '.last_operation.description')
   if [[ "${description}" =~ ${http_regex} ]]; then
     domain_external="${BASH_REMATCH[1]}"
     domain_internal="${BASH_REMATCH[2]}"
@@ -188,8 +188,8 @@ fi
 # Wait for provision to complete
 elapsed="${DOMAINS_TIMEOUT}"
 until [ "${elapsed}" -le 0 ]; do
-  status=$(cf curl "/v2/service_instances/${service_guid}")
-  state=$(echo "${status}" | jq -r '.entity.last_operation.state')
+  status=$(cf curl "/v3/service_instances/${service_guid}")
+  state=$(echo "${status}" | jq -r '.last_operation.state')
   if [[ "${state}" == "succeeded" ]]; then
     updated="true"
     break


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the acceptance tests to use the CAPI v3 service_instances endpoint
- This PR is only needed if this broker isn't going to the 🌋 
- Part of https://github.com/cloud-gov/cf-domain-broker-alb/issues/60
-

## Security considerations

Switches to using the maintained CAPI v3 endpoints
